### PR TITLE
Fix SVG transform issue in IE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/anime.js
+++ b/anime.js
@@ -332,6 +332,10 @@
   var getTweenValues = function(prop, values, type, target) {
     var valid = {};
     if (type === 'transform') {
+      /*
+       * The SVG transform attribute does not take units, so we 
+       * must test for this.
+       */
       if (target instanceof SVGElement) {
         valid.from = prop + '(' + values.from + ')';
         valid.to = prop + '(' + values.to + ')';
@@ -496,6 +500,10 @@
         var target = anim.animatables[t].target,
           transformValue = transforms[t].join(' ');
         
+        /*
+         * IE <= 10 has a problem with SVG and CSS transforms, so 
+         * we have to work around this.
+         */
         if (target instanceof SVGElement) {
           target.setAttribute('transform', transformValue)
         } else {

--- a/anime.js
+++ b/anime.js
@@ -332,13 +332,13 @@
   var getTweenValues = function(prop, values, type, target) {
     var valid = {};
     if (type === 'transform') {
-    	if (target instanceof SVGElement) {
-    		valid.from = prop + '(' + values.from + ')';
-	      valid.to = prop + '(' + values.to + ')';
-    	} else {
-	      valid.from = prop + '(' + addDefaultTransformUnit(prop, values.from, values.to) + ')';
-	      valid.to = prop + '(' + addDefaultTransformUnit(prop, values.to) + ')';
-	    }
+      if (target instanceof SVGElement) {
+        valid.from = prop + '(' + values.from + ')';
+        valid.to = prop + '(' + values.to + ')';
+      } else {
+        valid.from = prop + '(' + addDefaultTransformUnit(prop, values.from, values.to) + ')';
+        valid.to = prop + '(' + addDefaultTransformUnit(prop, values.to) + ')';
+      }
     } else {
       var originalCSS = (type === 'css') ? getCSSValue(target, prop) : undefined;
       valid.from = getValidValue(values, values.from, originalCSS);
@@ -484,24 +484,24 @@
           case 'attribute': animatable.target.setAttribute(tween.name, progress); break;
           case 'object': animatable.target[tween.name] = progress; break;
           case 'transform':
-          	if (!transforms) transforms = {};
-	          if (!transforms[id]) transforms[id] = [];
-	          transforms[id].push(progress);
-	          break;
+            if (!transforms) transforms = {};
+            if (!transforms[id]) transforms[id] = [];
+            transforms[id].push(progress);
+            break;
         }
       });
     });
     if (transforms) {
-    	for (var t in transforms) {
-    		var target = anim.animatables[t].target,
-    			transformValue = transforms[t].join(' ');
-    		
-    		if (target instanceof SVGElement) {
-    			target.setAttribute('transform', transformValue)
-    		} else {
-    			target.style.transform = transformValue;
-    		}
-    	}
+      for (var t in transforms) {
+        var target = anim.animatables[t].target,
+          transformValue = transforms[t].join(' ');
+        
+        if (target instanceof SVGElement) {
+          target.setAttribute('transform', transformValue)
+        } else {
+          target.style.transform = transformValue;
+        }
+      }
     }
     if (anim.settings.update) anim.settings.update(anim);
   }

--- a/anime.js
+++ b/anime.js
@@ -247,7 +247,7 @@
     var isSVG = (el instanceof SVGElement);
     
     /*
-     * IE <= 10 has a problem with SVG and CSS transforms, so 
+     * IE has a problem with SVG and CSS transforms, so 
      * we have to work around this.
      */
     var str = isSVG ? el.getAttribute('transform') : el.style.transform
@@ -501,7 +501,7 @@
           transformValue = transforms[t].join(' ');
         
         /*
-         * IE <= 10 has a problem with SVG and CSS transforms, so 
+         * IE has a problem with SVG and CSS transforms, so 
          * we have to work around this.
          */
         if (target instanceof SVGElement) {

--- a/examples/js/motion-path.js
+++ b/examples/js/motion-path.js
@@ -1,0 +1,19 @@
+var path = anime.path('path');
+
+anime({
+  targets: 'rect',
+  translate: path,
+  rotate: path,
+  duration: 3000,
+  loop: true,
+  easing: 'linear'
+});
+
+anime({
+  targets: 'path',
+  opacity: 0,
+  duration: 6000,
+  loop: true,
+  direction: 'alternate',
+  easing: 'easeInOutExpo'
+});

--- a/examples/motion-path.html
+++ b/examples/motion-path.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html data-smil-js-debug="true">
+	<head>
+		<title>anime Motion Path Example</title>
+		
+		<style>
+		  body {
+		  	background: black;
+		  }
+		  
+			div {
+				width: 2rem;
+				height: 2rem;
+				margin-top: auto;
+				margin-bottom: auto;
+			}
+		</style>
+		
+	</head>
+	<body>
+		<section>
+			<article>
+				<svg width="256" height="112" viewBox="0 0 256 112">
+					<path fill="none" stroke="#FFF" d="M8,56 C8,33.90861 25.90861,16 48,16 C70.09139,16 88,33.90861 88,56 C88,78.09139 105.90861,92 128,92 C150.09139,92 160,72 160,56 C160,40 148,24 128,24 C108,24 96,40 96,56 C96,72 105.90861,92 128,92 C154,93 168,78 168,56 C168,33.90861 185.90861,16 208,16 C230.09139,16 248,33.90861 248,56 C248,78.09139 230.09139,96 208,96 L48,96 C25.90861,96 8,78.09139 8,56 Z"/>
+					<rect fill="#38FF9B" width="16" height="16" x="-8" y="-8" transform="rotate(45)"/>
+				</svg>
+			</article>
+			
+		</section>
+		
+		<script src="../anime.js"></script>
+		<script src="js/motion-path.js"></script>
+	</body>
+</html>

--- a/examples/motion-path.html
+++ b/examples/motion-path.html
@@ -1,34 +1,34 @@
 <!DOCTYPE html>
 <html data-smil-js-debug="true">
-	<head>
-		<title>anime Motion Path Example</title>
-		
-		<style>
-		  body {
-		  	background: black;
-		  }
-		  
-			div {
-				width: 2rem;
-				height: 2rem;
-				margin-top: auto;
-				margin-bottom: auto;
-			}
-		</style>
-		
-	</head>
-	<body>
-		<section>
-			<article>
-				<svg width="256" height="112" viewBox="0 0 256 112">
-					<path fill="none" stroke="#FFF" d="M8,56 C8,33.90861 25.90861,16 48,16 C70.09139,16 88,33.90861 88,56 C88,78.09139 105.90861,92 128,92 C150.09139,92 160,72 160,56 C160,40 148,24 128,24 C108,24 96,40 96,56 C96,72 105.90861,92 128,92 C154,93 168,78 168,56 C168,33.90861 185.90861,16 208,16 C230.09139,16 248,33.90861 248,56 C248,78.09139 230.09139,96 208,96 L48,96 C25.90861,96 8,78.09139 8,56 Z"/>
-					<rect fill="#38FF9B" width="16" height="16" x="-8" y="-8" transform="rotate(45)"/>
-				</svg>
-			</article>
-			
-		</section>
-		
-		<script src="../anime.js"></script>
-		<script src="js/motion-path.js"></script>
-	</body>
+  <head>
+    <title>anime Motion Path Example</title>
+    
+    <style>
+      body {
+        background: black;
+      }
+      
+      div {
+        width: 2rem;
+        height: 2rem;
+        margin-top: auto;
+        margin-bottom: auto;
+      }
+    </style>
+    
+  </head>
+  <body>
+    <section>
+      <article>
+        <svg width="256" height="112" viewBox="0 0 256 112">
+          <path fill="none" stroke="#FFF" d="M8,56 C8,33.90861 25.90861,16 48,16 C70.09139,16 88,33.90861 88,56 C88,78.09139 105.90861,92 128,92 C150.09139,92 160,72 160,56 C160,40 148,24 128,24 C108,24 96,40 96,56 C96,72 105.90861,92 128,92 C154,93 168,78 168,56 C168,33.90861 185.90861,16 208,16 C230.09139,16 248,33.90861 248,56 C248,78.09139 230.09139,96 208,96 L48,96 C25.90861,96 8,78.09139 8,56 Z"/>
+          <rect fill="#38FF9B" width="16" height="16" x="-8" y="-8" transform="rotate(45)"/>
+        </svg>
+      </article>
+      
+    </section>
+    
+    <script src="../anime.js"></script>
+    <script src="js/motion-path.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
The motion-path example wasn't working in IE, since IE cannot apply CSS transforms on SVG elements.  (See https://connect.microsoft.com/IE/feedback/details/811744/ie11-bug-with-implementation-of-css-transforms-in-svg)

This pull request fixes this issue.  I also put into the PR an HTML file that shows it working.

If you want me to modify this pull request to conform to code standards, please let me know.  I want to help this project if I can.

Cheers!

Zoltan.