### PR TITLE
Update transform prefix handler

### DIFF
--- a/anime.js
+++ b/anime.js
@@ -496,9 +496,12 @@
       }
     }
     if (transforms) {
-      if (!transform) transform = (getCSSValue(document.body, transformStr) ? '' : '-webkit-') + transformStr;
       for (var t in transforms) {
-        anim.animatables[t].target.style[transform] = transforms[t].join(' ');
+        var transformTarget = anim.animatables[t].target;
+        var transformValue = transforms[t].join(' ');
+        transformTarget.style.transform = transformValue;
+        transformTarget.style.webkitTransform = transformValue;
+        transformTarget.style.msTransform = transformValue;
       }
     }
     if (anim.settings.update) anim.settings.update(anim);


### PR DESCRIPTION
```
if (!transform) transform = (getCSSValue(document.body, transformStr) ? '' : '-webkit-') + transformStr;		
for (var t in transforms) {
  anim.animatables[t].target.style[transform] = transforms[t].join(' ');
}
```
This code doesn't work and you don't need to check -webkit- prefix.
I modified the code to browsers apply that property if support it.
And It can be work even IE9, especially if you use msTransform. (by using animationRequestFrame polyfill)