### PR TITLE
Fix for environments without requestAnimationFrame function

### DIFF
--- a/anime.js
+++ b/anime.js
@@ -40,6 +40,16 @@
     complete: undefined
   }
 
+  // Fix for environments that have no requestAnimationFrame by default
+  window.requestAnimationFrame = function() {
+    return window.requestAnimationFrame ||
+	   window.webkitRequestAnimationFrame ||
+	   window.mozRequestAnimationFrame ||
+	   function (callback) {
+	     window.setTimeout(callback, 1000 / 60);
+	   };
+  }();
+
   // Transforms
 
   var validTransforms = ['translateX', 'translateY', 'translateZ', 'rotate', 'rotateX', 'rotateY', 'rotateZ', 'scale', 'scaleX', 'scaleY', 'scaleZ', 'skewX', 'skewY'];

--- a/anime.js
+++ b/anime.js
@@ -41,13 +41,23 @@
   }
 
   // Fix for environments that have no requestAnimationFrame by default
+  var fallbackLastAnimationTime = 0;
   var animeRequestAnimationFrame = window.requestAnimationFrame ||
     window.webkitRequestAnimationFrame ||
     window.mozRequestAnimationFrame ||
-    function (callback) {
-      window.setTimeout(callback, 1000 / 60);
+    function (callback) { 
+      var currTime = new Date().getTime();
+      var timeToCall = Math.max(0, 16 - (currTime - fallbackLastAnimationTime));
+			return window.setTimeout( 
+        callback.bind(this, currTime + fallbackLastAnimationTime), 
+        1000 / 60 );
     };
-
+  var animeCancelAnimationFrame = window.cancelAnimationFrame || 
+    window.webkitCancelAnimationFrame || 
+    window.mozCancelAnimationFrame ||
+    function(id) {
+       window.clearTimeout(id);
+    };
 
   // Transforms
 
@@ -538,7 +548,7 @@
         for (var i = 0; i < animations.length; i++) animations[i].tick(t);
         play();
       } else {
-        cancelAnimationFrame(raf);
+        animeCancelAnimationFrame(raf);
         raf = 0;
       }
     }

--- a/anime.js
+++ b/anime.js
@@ -41,14 +41,13 @@
   }
 
   // Fix for environments that have no requestAnimationFrame by default
-  window.requestAnimationFrame = function() {
-    return window.requestAnimationFrame ||
-	   window.webkitRequestAnimationFrame ||
-	   window.mozRequestAnimationFrame ||
-	   function (callback) {
-	     window.setTimeout(callback, 1000 / 60);
-	   };
-  }();
+  var animeRequestAnimationFrame = window.requestAnimationFrame ||
+    window.webkitRequestAnimationFrame ||
+    window.mozRequestAnimationFrame ||
+    function (callback) {
+      window.setTimeout(callback, 1000 / 60);
+    };
+
 
   // Transforms
 
@@ -533,7 +532,7 @@
   var raf = 0;
 
   var engine = (function() {
-    var play = function() { raf = requestAnimationFrame(step); };
+    var play = function() { raf = animeRequestAnimationFrame(step); };
     var step = function(t) {
       if (animations.length) {
         for (var i = 0; i < animations.length; i++) animations[i].tick(t);


### PR DESCRIPTION
I've had problems with using animejs in unit tests, it failed on requestAnimationFrame(). I suppose it will be nice to have this covered inside library so it will launch in cases like mine or even on ancient browsers. 
