### PR TITLE
Initial implementation for Promise resolution

### DIFF
--- a/anime.js
+++ b/anime.js
@@ -652,6 +652,9 @@
   function anime(params = {}) {
 
     let now, startTime, lastTime = 0;
+    let resolve = null;
+    let promise = makePromise();
+
     let instance = createNewInstance(params);
 
     instance.reset = function() {
@@ -664,6 +667,10 @@
       instance.completed = false;
       instance.reversed = direction === 'reverse';
       instance.remaining = direction === 'alternate' && loops === 1 ? 2 : loops;
+    }
+
+    function makePromise() {
+      return window.Promise && new Promise(_resolve => resolve = _resolve);
     }
 
     function toggleInstanceDirection() {
@@ -744,6 +751,8 @@
         } else {
           instance.completed = true;
           instance.pause();
+          resolve();
+          promise = makePromise();
           setCallback('complete');
         }
         lastTime = 0;
@@ -789,6 +798,9 @@
       instance.reset();
       instance.play();
     }
+
+    // Attach finished promise to instance
+    instance.finished = promise;
 
     instance.reset();
 

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1302,8 +1302,53 @@ complete.update = function(anim) {
 </article>
 <!-- -->
 
+<!-- PROMISES -->
+<article id="promises" class="color-10">
+<header>
+  <h2 class="demos-title">Promises</h2>
+</header>
+
+<div id="finishedPromise" class="demo">
+  <h3 class="demo-title">Finished</h3>
+  <div class="demo-content">
+    <div class="logs">
+      <input class="log finished-log"></input>
+    </div>
+    <div class="large square shadow"></div>
+    <div class="large square el"></div>
+  </div>
+<script>var finishedLogEl = document.querySelector('#finishedPromise .finished-log');
+
+var finishedPromise = anime({
+  targets: '#promises .el',
+  translateX: 250,
+  delay: 1000
+});
+
+var promise = finishedPromise.finished.then(logFinished);
+
+function logFinished() {
+  finishedLogEl.value = 'Promise resolved';
+
+  // Rebind the promise, since this demo can be looped.
+  setTimeout(() => {
+    promise = finishedPromise.finished.then(logFinished);
+  });
+}
+
+finishedPromise.update = function(anim) {
+  if (!anim.completed) {
+    finishedLogEl.value = '';
+  }
+}
+</script>
+</div>
+
+</article>
+<!-- -->
+
 <!-- SVG -->
-<article id="svg" class="color-10">
+<article id="svg" class="color-11">
 <header>
   <h2 class="demos-title">SVG</h2>
 </header>
@@ -1397,7 +1442,7 @@ var motionPath = anime({
 <!-- -->
 
 <!-- EASINGS -->
-<article id="easings" class="color-11">
+<article id="easings" class="color-12">
   <header>
     <h2 class="demos-title">Easings</h2>
   </header>


### PR DESCRIPTION
This commit adds a `finished` property to the anime instance object
which will resolve whenever the animation has completed. As promises
are an immutable resolution (meaning set-in-stone), we cannot simply
re-resolve the Promise per tick as the `setCallbacks` function works.
Therefore the `finished` property is reset after each successful
completion which allows the end user to rebind if desired.

The inspiration for this property comes from the Web Animations
specification:
https://developer.mozilla.org/en-US/docs/Web/API/Animation/finished

While the end-user could implement this resolution within their own
application, I feel that developers will appreciate the added
convenience in their code with this approach. For instance, Mocha the JS
test runner, supports returning promises from within
describe/before/after/it/etc blocks which results in significantly
cleaner code.

My use case for this change is within a library I maintain called
diffHTML that accepts Promises to delay rendering until
animations/transitions have completed.

An example of the possible integration after this change:

``` js
// Assume diffHTML is already global...
const { innerHTML, addTransitionState, html } = diff;

// Animate elements once they are attached to the DOM.
addTransitionState('attached', targets => anime({
  targets,
  translateX: 250
}).finished);

// Add elements into the DOM.
innerHTML(document.body, html`
  <center>Animate</center>
  <center>This</center>
  <center>In!</center>
`);
```

Another way to use this Promise:

``` js
const targets = getTargets();

const { finished } = anime({
  targets,
  translateX: 250
});

finished(() => {
  console.log('Animation completed');
});
```

Looking forward to feedback!