### PR TITLE
Remove ligatures from code samples in docs

### DIFF
--- a/documentation/assets/css/documentation.css
+++ b/documentation/assets/css/documentation.css
@@ -210,6 +210,7 @@ header {
 pre {
   overflow: auto;
   font-family: 'Space Mono', monospace;
+  font-variant-ligatures: none;
   line-height: 22px;
 }
 

--- a/documentation/assets/css/documentation.css
+++ b/documentation/assets/css/documentation.css
@@ -211,6 +211,7 @@ pre {
   overflow: auto;
   font-family: 'Space Mono', monospace;
   font-variant-ligatures: none;
+  -webkit-font-variant-ligatures: none;
   line-height: 22px;
 }
 


### PR DESCRIPTION
By removing font ligatures from the docs, the code samples render properly. Ligatures look great for plain text (especially in non-monospace fonts), but Space Mono ships monospace ligatures which don't make sense for an application like this. See the attached files for a comparison - in the before image, see the `</` and `fi` samples compared to the after:

<img width="453" alt="before" src="https://user-images.githubusercontent.com/6288183/30867218-443804fc-a2d3-11e7-996a-8328c62ba825.png">

<img width="425" alt="after" src="https://user-images.githubusercontent.com/6288183/30867213-3e41c222-a2d3-11e7-8f11-201bacaf29d7.png">
