### PR TITLE
Fix engineTime calculation in tick() for speeds less than 1

### DIFF
--- a/anime.js
+++ b/anime.js
@@ -882,7 +882,7 @@
     instance.tick = function(t) {
       now = t;
       if (!startTime) startTime = now;
-      const engineTime = (lastTime + now - startTime) * anime.speed;
+      const engineTime = ((lastTime * (1 / anime.speed)) + now - startTime) * anime.speed;
       setInstanceProgress(engineTime);
     }
 


### PR DESCRIPTION
With `anime.speed` less than `1` the playback controls aren't working correctly. For example *play* in the "Time Controls" example doesn't continue where *pause* left off. This seems to be due to the fact that `lastTime` in `tick()` doesn't account for `anime.speed`.