### PR TITLE
Two new callbacks to indicate loops

### DIFF
--- a/anime.js
+++ b/anime.js
@@ -27,6 +27,9 @@
   const defaultInstanceSettings = {
     update: undefined,
     begin: undefined,
+    loopBegin: undefined,
+    loopEnd: undefined,
+    loopBegan: false,
     run: undefined,
     complete: undefined,
     loop: 1,
@@ -829,16 +832,24 @@
           instance.began = true;
           setCallback('begin');
         }
+        if(!instance.loopBegan){
+          instance.loopBegan=true;
+          setCallback("loopBegin");
+        }
         setCallback('run');
       }
       if (insTime > insOffset && insTime < insDuration) {
         setAnimationsProgress(insTime);
       } else {
         if (insTime <= insOffset && insCurrentTime !== 0) {
+          setCallback("loopEnd");
+          instance.loopBegan = false;
           setAnimationsProgress(0);
           if (insReversed) countIteration();
         }
         if ((insTime >= insDuration && insCurrentTime !== insDuration) || !insDuration) {
+          setCallback("loopEnd");
+          instance.loopBegan = false;
           setAnimationsProgress(insDuration);
           if (!insReversed) countIteration();
         }


### PR DESCRIPTION
At the moment we have a begin and end but of the whole animation, situations could arise that you need to know when a loop begins and when it ends. loopBegin and loopEnd will fire when a iteration will start and when it will end.

Example with a loop set to three

```
13:09:12.577 duration-0 begin
13:09:12.578 duration-0 loopBegin
13:09:17.577 duration-0 loopEnd
13:09:17.594 duration-0 loopBegin
13:09:22.577 duration-0 loopEnd
13:09:22.594 duration-0 loopBegin
13:09:28.827 duration-0 loopEnd
13:09:28.828 duration-0 complete 
```