### PR TITLE
fixed value in documentation

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -2460,7 +2460,7 @@ tl
 .add({
   targets: '.offsets-demo .el.triangle',
   translateX: 250,
-}, 0); // absolute offset
+}, 400); // absolute offset
 
 /*DEMO*/
 }


### PR DESCRIPTION
Regarding this line 2438: <div class="label">absolute offset (400)</div>

The value in code should also be 400.
I expect it to be this way around as it is more interesting than absolute 0

Documentation: https://animejs.com/documentation/#timelineOffsets