### PR TITLE
README: Update import/require path in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ or manual [download](https://github.com/juliangarnier/anime/archive/master.zip).
 #### ES6 modules
 
 ```javascript
-import anime from 'lib/anime.es.js';
+import anime from 'anime';
 ```
 
 #### CommonJS
 
 ```javascript
-const anime = require('lib/anime.js');
+const anime = require('anime');
 ```
 
 #### File include


### PR DESCRIPTION
## README: Update import/require path in examples

This update fixes the import/require paths for the `animejs` module when
using it from `node_modules`.

Since the paths are defined in `package.json`, node will use
`node_modules/animejs/lib` as the root :)