### PR TITLE
Add spring and cubicBezier helper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1173,7 +1173,6 @@ function removeTargets(targets) {
 }
 
 // Stagger helpers
-
 function stagger(val, params = {}) {
   const direction = params.direction || 'normal';
   const easing = params.easing ? parseEasings(params.easing) : null;
@@ -1254,6 +1253,26 @@ function timeline(params = {}) {
   }
   return tl;
 }
+
+/**
+ * 
+ * @param {number[]|string[]} params 
+ * @example ```js
+ cubicBezier([.5, .05, .1, .3]) // 'cubicBezier(0.5,0.05,0.1,0.3)'
+ ```
+ */
+export const cubicBezier = (params) => `cubicBezier(${params.join(',')})`
+
+/**
+ * @param {number|string} mass 
+ * @param {number|string} stiffness 
+ * @param {number|string} damping 
+ * @param {number|string} velocity
+ * @example ```js 
+ spring(1,100,10, 0) // -> 'spring(1, 100, 10, 0)'
+ ```
+ */
+export const spring = (mass, stiffness, damping, velocity) => `spring(${mass},${stiffness},${damping},${velocity})`
 
 anime.version = '3.0.1';
 anime.speed = 1;


### PR DESCRIPTION
I don't know why, you changed the way cubicBezier was defined in your library, but it’s easy to make a mistake this way, so I suggest adding 2 helpers to create strings.

I also don’t see yarn-lock or package-lock in the repository, so I don’t even know through which package manager to install dependencies in your project.

And if we use es modules, I suggest using named export for helpers. Instead
```js
import anime from 'animejs'
anime({ delay: anime.stagger(100), easing: anime.cubicBezier([1,.25,0,1]) })
```
use it
```js
import anime, { stagger, cubicBezier } from 'animejs'
anime({ delay: stagger(100), easing: cubicBezier([1,.25,0,1])  })
```
Code editors for named exports can automatically import the desired helper.