### PR TITLE
Fix getParentSvgEl which returned the wrong item

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ function elastic(amplitude = 1, period = .5) {
   const a = minMax(amplitude, 1, 10);
   const p = minMax(period, .1, 2);
   return t => {
-    return (t === 0 || t === 1) ? t : 
+    return (t === 0 || t === 1) ? t :
       -a * Math.pow(2, 10 * (t - 1)) * Math.sin((((t - 1) - (p / (Math.PI * 2) * Math.asin(1 / a))) * (Math.PI * 2)) / p);
   }
 }
@@ -262,7 +262,7 @@ const penner = (() => {
     ]
   }
 
-  let eases = { 
+  let eases = {
     linear: [0.250, 0.250, 0.750, 0.750]
   }
 
@@ -523,7 +523,7 @@ function getRectLength(el) {
 
 function getLineLength(el) {
   return getDistance(
-    {x: getAttribute(el, 'x1'), y: getAttribute(el, 'y1')}, 
+    {x: getAttribute(el, 'x1'), y: getAttribute(el, 'y1')},
     {x: getAttribute(el, 'x2'), y: getAttribute(el, 'y2')}
   );
 }
@@ -569,8 +569,8 @@ function setDashoffset(el) {
 function getParentSvgEl(el) {
   let parentEl = el.parentNode;
   while (is.svg(parentEl)) {
-    parentEl = parentEl.parentNode;
     if (!is.svg(parentEl.parentNode)) break;
+    parentEl = parentEl.parentNode;
   }
   return parentEl;
 }
@@ -858,7 +858,7 @@ let pausedInstances = [];
 let raf;
 
 const engine = (() => {
-  function play() { 
+  function play() {
     raf = requestAnimationFrame(step);
   }
   function step(t) {

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ function elastic(amplitude = 1, period = .5) {
   const a = minMax(amplitude, 1, 10);
   const p = minMax(period, .1, 2);
   return t => {
-    return (t === 0 || t === 1) ? t :
+    return (t === 0 || t === 1) ? t : 
       -a * Math.pow(2, 10 * (t - 1)) * Math.sin((((t - 1) - (p / (Math.PI * 2) * Math.asin(1 / a))) * (Math.PI * 2)) / p);
   }
 }
@@ -262,7 +262,7 @@ const penner = (() => {
     ]
   }
 
-  let eases = {
+  let eases = { 
     linear: [0.250, 0.250, 0.750, 0.750]
   }
 
@@ -523,7 +523,7 @@ function getRectLength(el) {
 
 function getLineLength(el) {
   return getDistance(
-    {x: getAttribute(el, 'x1'), y: getAttribute(el, 'y1')},
+    {x: getAttribute(el, 'x1'), y: getAttribute(el, 'y1')}, 
     {x: getAttribute(el, 'x2'), y: getAttribute(el, 'y2')}
   );
 }
@@ -858,7 +858,7 @@ let pausedInstances = [];
 let raf;
 
 const engine = (() => {
-  function play() {
+  function play() { 
     raf = requestAnimationFrame(step);
   }
   function step(t) {


### PR DESCRIPTION
**Fix getParentSvgEl**

This PR for fix bug with function `getParentSvgEl` which returned parent of SVG element, but not root SVG element (HTML <svg> tag). It's need for responsive animation with "motion path".

The solution is simple. We need just replce break condition up for one line before `parentEl` remains root SVG element.

This example to demonstrate the problem: https://codepen.io/spz/pen/MxYywK?editors=1111
This example of resolved problem (with build animejs after fix function): https://codepen.io/spz/pen/zbxqQW?editors=1011
