### PR TITLE
Update anime.running reference when clearing array on visibilitychange

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -890,7 +890,7 @@ function handleVisibilityChange() {
   if (document.hidden) {
     activeInstances.forEach(ins => ins.pause());
     pausedInstances = activeInstances.slice(0);
-    activeInstances = [];
+    anime.running = activeInstances = [];
   } else {
     pausedInstances.forEach(ins => ins.play());
   }


### PR DESCRIPTION
Fixes issue (#560, #466) with `anime.running` helper not working correctly after changing page/tab triggering `visibilitychange` event.

Fix assigns the new empty array to both `anime.running` AND `activeInstances` ensuring they are using the same reference, which allows `anime.running` to function normally. 

If the multiple left-hand assignment is an issue (code style wise) I can happily change.

P.S - Thanks for the awesome lib!