### PR TITLE
Fix scaling of path animations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -616,8 +616,8 @@ function getPathProgress(path, progress) {
   const p0 = point(-1);
   const p1 = point(+1);
   switch (path.property) {
-    case 'x': return (p.x - svg.x) * svg.w;
-    case 'y': return (p.y - svg.y) * svg.h;
+    case 'x': return (p.x - svg.x);
+    case 'y': return (p.y - svg.y);
     case 'angle': return Math.atan2(p1.y - p0.y, p1.x - p0.x) * 180 / Math.PI;
   }
 }


### PR DESCRIPTION
Scaling for paths was not working for me.  If the SVG image was larger than the viewbox, the x / y values would be too large.  If the SVG image was smaller than the viewbox, the x / y values would be too small.

Removing the multiplication of the scaling factor has solved this issue.