### PR TITLE
Fix link to grid staggering

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -2108,7 +2108,7 @@ anime({
   <h3 class="demo-title">Axis</h3>
   <div class="demo-description">
     <p>
-      Forces the direction of a <a href="gridStaggering" class="color-staggering">grid starrering</a> effect.
+      Forces the direction of a <a href="#gridStaggering" class="color-staggering">grid starrering</a> effect.
     </p>
     <pre><code>anime.stagger(value, {grid: [rows, columns], axis: 'x'})</code></pre>
     <table>


### PR DESCRIPTION
The link is currently broken as the documentation uses IDs for sections.
<img width="1552" alt="Screen Shot 2019-09-16 at 11 31 55 AM" src="https://user-images.githubusercontent.com/6239076/64971423-ae62e200-d875-11e9-881f-24214f8362fc.png">

Change to `#gridStaggering` to make it work again.