### PR TITLE
fixes #556: responsive scaling when animating along SVG path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -594,8 +594,8 @@ function getPathProgress(path, progress) {
   const p0 = point(-1);
   const p1 = point(+1);
   switch (path.property) {
-    case 'x': return (p.x - svg.x) * svg.w;
-    case 'y': return (p.y - svg.y) * svg.h;
+    case 'x': return (p.x - svg.x);
+    case 'y': return (p.y - svg.y);
     case 'angle': return Math.atan2(p1.y - p0.y, p1.x - p0.x) * 180 / Math.PI;
   }
 }


### PR DESCRIPTION
When the svg is scaled by DOM scaling, the path will be scaled twice without this change. This change in function getPathProgress moves away the multiplication of svg dimensions.  When I want to animate obejct along the path(the path is inside a scaled svg), the object will follow the scaled path, which is not what I want. I would like to have the object move along the original path instead of the scaled path.