### PR TITLE
fix step easing by implementing jump-start method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ function spring(string, duration) {
 // Basic steps easing implementation https://developer.mozilla.org/fr/docs/Web/CSS/transition-timing-function
 
 function steps(steps = 10) {
-  return t => Math.round(t * steps) * (1 / steps);
+  return t => Math.ceil(t * steps) * (1 / steps);
 }
 
 // BezierEasing https://github.com/gre/bezier-easing


### PR DESCRIPTION
There are at least 4 ways to implement a step easing: `jump-start`, `jump-end`, `jump-none`, `jump-both` (https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function).

However, the API seems to prefer simplicity so I only implemented one here: jump-start. Happy to provide the option to choose a different variation - just let me know.

`steps(5)` before:
![image](https://user-images.githubusercontent.com/8781763/77428100-ef502c00-6dad-11ea-8567-6489e9d3f722.png)

`steps(5)` after:
![image](https://user-images.githubusercontent.com/8781763/77428083-e7908780-6dad-11ea-8d62-23f784f02243.png)
