### PR TITLE
Add easeOutIn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -246,6 +246,8 @@ const penner = (() => {
     eases['easeOut' + name] = (a, b) => t => 1 - easeIn(a, b)(1 - t);
     eases['easeInOut' + name] = (a, b) => t => t < 0.5 ? easeIn(a, b)(t * 2) / 2 : 
       1 - easeIn(a, b)(t * -2 + 2) / 2;
+    eases['easeOutIn' + name] = (a, b) => t => t < 0.5 ? (1 - easeIn(a, b)(1 - t * 2)) / 2 : 
+      (easeIn(a, b)(t * 2 - 1) + 1) / 2;
   });
 
   return eases;


### PR DESCRIPTION
👋

This re-adds the `easeOutIn` easing functions that were removed in `v2.0.0`. (Originally discussed in #53).

Tbh, I originally thought they were left out unintentionally, although, I just noticed you mentioned the removal in the `v2.0.0` release notes so maybe there was some reason behind it (care to elaborate?).

Anyways, I know that not a lot of people use the `easeOutIn` easing functions, so here's an example to show when they're useful. (In this case, it's using `easeOutIn` on staggered delay).

---

✅ `easeOutIn` on staggered delay ([codepen](https://codepen.io/ryanpwaldon/pen/bGVMqEy)):
![ease-out-in](https://user-images.githubusercontent.com/12480362/81488090-9c6ffc80-92a7-11ea-9cd9-e0da51afd3ac.gif)

`easeInOut` on staggered delay ([codepen](https://codepen.io/ryanpwaldon/pen/jObxBpr)):
![ease-in-out](https://user-images.githubusercontent.com/12480362/81488084-92e69480-92a7-11ea-8778-7aabdc19c253.gif)

