### PR TITLE
change doc for ranged staggering

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1689,32 +1689,32 @@ anime({
   </div>
   <div class="demo-content range-value-staggering-demo">
     <div class="line">
-      <div class="label">rotate = ((360 - (-360)) / 5) * 0</div>
+      <div class="label">rotate = -360 + ((360 - (-360)) / 5) * 0</div>
       <div class="small square shadow"></div>
       <div class="small square el"></div>
     </div>
     <div class="line">
-      <div class="label">rotate = ((360 - (-360)) / 5) * 1</div>
+      <div class="label">rotate = -360 + ((360 - (-360)) / 5) * 1</div>
       <div class="small square shadow"></div>
       <div class="small square el"></div>
     </div>
     <div class="line">
-      <div class="label">rotate = ((360 - (-360)) / 5) * 2</div>
+      <div class="label">rotate = -360 + ((360 - (-360)) / 5) * 2</div>
       <div class="small square shadow"></div>
       <div class="small square el"></div>
     </div>
     <div class="line">
-      <div class="label">rotate = ((360 - (-360)) / 5) * 3</div>
+      <div class="label">rotate = -360 + ((360 - (-360)) / 5) * 3</div>
       <div class="small square shadow"></div>
       <div class="small square el"></div>
     </div>
     <div class="line">
-      <div class="label">rotate = ((360 - (-360)) / 5) * 4</div>
+      <div class="label">rotate = -360 + ((360 - (-360)) / 5) * 4</div>
       <div class="small square shadow"></div>
       <div class="small square el"></div>
     </div>
     <div class="line">
-      <div class="label">rotate = ((360 - (-360)) / 5) * 5</div>
+      <div class="label">rotate = -360 + ((360 - (-360)) / 5) * 5</div>
       <div class="small square shadow"></div>
       <div class="small square el"></div>
     </div>


### PR DESCRIPTION
The mathematical function for ranged staggering should have been described as `rotate = -360 + ((360 - (-360)) / 5) * i` for the ith element, but the start value(-360) was not written. 

Changed the labels to include the start value.