### PR TITLE
Small typo in documentation

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -951,17 +951,17 @@ anime({
       <div class="small square el loop-alternate"></div>
     </div>
     <div class="line">
-      <div class="small label">normal inifinite</div>
+      <div class="small label">normal infinite</div>
       <div class="small square shadow"></div>
       <div class="small square el loop-infinity"></div>
     </div>
     <div class="line">
-      <div class="small label">inifinite reverse</div>
+      <div class="small label">infinite reverse</div>
       <div class="small square shadow"></div>
       <div class="small square el loop-reverse-infinity"></div>
     </div>
     <div class="line">
-      <div class="small label">inifinite alternate</div>
+      <div class="small label">infinite alternate</div>
       <div class="small square shadow"></div>
       <div class="small square el loop-alternate-infinity"></div>
     </div>


### PR DESCRIPTION
Three instances of `infinite` were spelled `inifinite`