### PR TITLE
 Update index.html - documentation

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1931,7 +1931,7 @@ anime({
     <p>
       Staggering values based a 2D array that allow "ripple" effects.
     </p>
-    <pre><code>anime.stagger(value, {grid: [rows, columns]})</code></pre>
+    <pre><code>anime.stagger(value, {grid: [columns, rows]})</code></pre>
     <table>
       <thead>
         <td>Type</td>
@@ -1939,7 +1939,7 @@ anime({
       </thead>
       <tr>
         <td><code>array</code></td>
-        <td>A 2 items array, the first value is the number of rows, the second the number of columns</td>
+        <td>A 2-item array -- the first value is the number of columns, the second the number of rows</td>
       </tr>
     </table>
   </div>
@@ -2110,7 +2110,7 @@ anime({
     <p>
       Forces the direction of a <a href="#gridStaggering" class="color-staggering">grid starrering</a> effect.
     </p>
-    <pre><code>anime.stagger(value, {grid: [rows, columns], axis: 'x'})</code></pre>
+    <pre><code>anime.stagger(value, {grid: [columns, rows], axis: 'x'})</code></pre>
     <table>
       <thead>
         <td>Parameters</td>


### PR DESCRIPTION
Under the documentation for STAGGERING:GRID and STAGGERING:AXIS --- the syntax for `grid: [ rows, columns ]` is incorrect.  This documented syntax is *inverted* relative to anime.js working code. 

The working code for the demo includes `delay: anime.stagger(200, {grid: [14, 5], from: 'center'})`
Of course this correctly animates the 14 **column** x 5 **row** grid in the demo.  
So... [ 14: columns, 5: rows ]

This pull request corrects the documentation in 3 places - twice in STAGGERING:GRID and once in STAGGERING:AXIS.

Thank you for making such an amazing library, and for this beautiful documentation!