### PR TITLE
Feature/resolve evenbetter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1061,7 +1061,7 @@ function anime(params = {}) {
           setCallback('loopComplete');
           setCallback('complete');
           if (!instance.passThrough && 'Promise' in window) {
-            resolve();
+            resolve(instance);
             promise = makePromise(instance);
           }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const defaultInstanceSettings = {
   changeComplete: null,
   loopComplete: null,
   complete: null,
+  pauseBegin : null,
   loop: 1,
   direction: 'normal',
   autoplay: true,
@@ -903,8 +904,14 @@ function anime(params = {}) {
   let children, childrenLength = 0;
   let resolve = null;
 
+  function onResolve(_resolve){
+    instance.finishedState = 'fulfilled';
+    resolve = _resolve(instance);
+  }
+
   function makePromise(instance) {
-    const promise = window.Promise && new Promise(_resolve => resolve = _resolve);
+    instance.finishedState = 'pending';
+    const promise = window.Promise && new Promise( onResolve );
     instance.finished = promise;
     return promise;
   }
@@ -1120,6 +1127,7 @@ function anime(params = {}) {
   instance.pause = function() {
     instance.paused = true;
     resetTime();
+    setCallback('pauseBegin');
   }
 
   instance.play = function() {

--- a/src/index.js
+++ b/src/index.js
@@ -904,14 +904,14 @@ function anime(params = {}) {
   let children, childrenLength = 0;
   let resolve = null;
 
-  function onResolve(_resolve){
+  function doResolve( value ){
     instance.finishedState = 'fulfilled';
-    resolve = _resolve(instance);
+    resolve(value );
   }
 
   function makePromise(instance) {
     instance.finishedState = 'pending';
-    const promise = window.Promise && new Promise( onResolve );
+    const promise = window.Promise && new Promise( _resolve => resolve );
     instance.finished = promise;
     return promise;
   }
@@ -1068,7 +1068,7 @@ function anime(params = {}) {
           setCallback('loopComplete');
           setCallback('complete');
           if (!instance.passThrough && 'Promise' in window) {
-            resolve(instance);
+            doResolve(instance);
             promise = makePromise(instance);
           }
         }


### PR DESCRIPTION
the promise behind an animation is a bit awkward to use.  It is a deferred pattern that the anime controls internally and recreates. There are 2 situations that are problematic:
## Situation A
because the resolve does not return the instance i find that i am regularly assigning  a variable to the animation and then referring to that  in promises.  This is a bit awkward, especially for combined promises (like race, etc)  
```
Promise.race( [anime({targets : X}), anime({targets:Y})] )
   .then(()=>UmWhoWon())
```
### after this PR
```
Promise.race( [anime({targets : X}), anime({targets:Y})] )
   .then(winner=> chickenDinner(winner) )
```

## Situation B
An instance that is not in a timeline will never really resolve if there is no timeline attached but the animation is removed. 
This is because there is an internal pause that user-code cannot know about;
e.g.:
```
const a = anime({ targets : X});  
a.finished.then(a=>ohShitImBored() ); 
a.remove('*'); // this will remove all (selector based) targets and imply a pause
```
### after this PR
```
const ImTheBossOfMe = function(a){
   //some stuff
   a.play();
}
const a = anime({ targets : X, onPause: ImTheBossOfMe });  
a.finished.then(a=>definitelyGettingHereNow() ); 
a.remove('*'); // this will remove all (selector based) targets and imply a pause...BUT WHO CARES NOW 😄 
```