### PR TITLE
add limit to `getDuration()` in `spring` function to avoid infinite loops

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,11 @@ function parseEasingParameters(string) {
   return match ? match[1].split(',').map(p => parseFloat(p)) : [];
 }
 
-// Spring solver inspired by Webkit Copyright © 2016 Apple Inc. All rights reserved. https://webkit.org/demos/spring/spring.js
+// Spring solver inspired by Webkit Copyright © 2016 Apple Inc. All rights reserved. https://webkit.org/demos/spring/spring.js 
+/**
+ * The number of iterations before a loop can be counted as an infinite loop
+ */
+const INTINITE_LOOP_LIMIT = 10000;
 
 function spring(string, duration) {
 
@@ -96,14 +100,17 @@ function spring(string, duration) {
     if (t === 0 || t === 1) return t;
     return 1 - progress;
   }
-
+  
   function getDuration() {
     const cached = cache.springs[string];
     if (cached) return cached;
     const frame = 1/6;
     let elapsed = 0;
     let rest = 0;
-    while(true) {
+    let count = 0;
+    
+    // To avoid infinite loops, stop loop when count reaches `INTINITE_LOOP_LIMIT`
+    while(++count < INTINITE_LOOP_LIMIT) {
       elapsed += frame;
       if (solver(elapsed) === 1) {
         rest++;


### PR DESCRIPTION
The way the `getDuration()` method in the `spring()` function is setup it doesn't have any way of stopping an infinite loop. I added a `INTINITE_LOOP_LIMIT` of 10,000 to stop possible infinite loop situations.