### PR TITLE
Add playbackRate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ const defaultInstanceSettings = {
   loop: 1,
   direction: 'normal',
   autoplay: true,
-  timelineOffset: 0
+  timelineOffset: 0,
+  playbackRate: 1
 }
 
 const defaultTweenSettings = {
@@ -927,7 +928,7 @@ function anime(params = {}) {
 
   function resetTime() {
     startTime = 0;
-    lastTime = adjustTime(instance.currentTime) * (1 / anime.speed);
+    lastTime = adjustTime(instance.currentTime) * (1 / anime.speed) * (1 / instance.playbackRate);
   }
 
   function seekChild(time, child) {
@@ -1110,7 +1111,7 @@ function anime(params = {}) {
   instance.tick = function(t) {
     now = t;
     if (!startTime) startTime = now;
-    setInstanceProgress((now + (lastTime - startTime)) * anime.speed);
+    setInstanceProgress((now + (lastTime - startTime)) * anime.speed * instance.playbackRate);
   }
 
   instance.seek = function(time) {


### PR DESCRIPTION
This PR adds a playbackRate option to anime, which allows an animation to play faster/slower than originally intended.

Rationale:
I have some css animations with keyframes with a user overridden duration, like this:
```
@keyframe 0% {...}
@keyframe 23% {...}
...
animation-duration: CHOSEN BY THE USER
```

Since animeJs does not support % keyframes, but only durations, in order to be able to override the duration I'd need to either:
a) make a function that generates the animation by multiplying each duration by some amount
b) make a function that goes over the animation object and multiplies durations, delays, endDelays, time offsets and so on keys by this amount.

Option a is not possible since animations need to be serialized and loaded from a JSON.
Option b is possible, but annoying

Although perhaps the preferable way to solve this issue would be to allow keyframes to express their durations and delays in "x%" in addition to msecs, this PR would solve it by allowing an animation to have a "playbackRate", which would solve my case by making all the base animations 1 second, each % keyframe "0.%" seconds, and setting the playbackRate to the user overridden number of seconds he wants the animation to last.