### PR TITLE
Clean up plus sign spacing in documentation page

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -2850,8 +2850,8 @@ anime({
   easing: 'easeInOutCirc',
   update: function(anim) {
     updates++;
-    progressLogEl.value = 'progress : '+Math.round(anim.progress)+'%';
-    updateLogEl.value = 'updates : '+updates;
+    progressLogEl.value = 'progress : ' + Math.round(anim.progress)+'%';
+    updateLogEl.value = 'updates : ' + updates;
   }
 });
 /*DEMO*/
@@ -3022,7 +3022,7 @@ anime({
   loop: true,
   easing: 'easeInOutCirc',
   update: function(anim) {
-    progressLogEl.value = 'progress : '+Math.round(anim.progress)+'%';
+    progressLogEl.value = 'progress : ' + Math.round(anim.progress)+'%';
   },
   change: function() {
     changes++;
@@ -3084,7 +3084,7 @@ anime({
   direction: 'alternate',
   easing: 'easeInOutCirc',
   update: function(anim) {
-    progressLogEl.value = 'progress : '+Math.round(anim.progress)+'%';
+    progressLogEl.value = 'progress : ' + Math.round(anim.progress) + '%';
   },
   changeBegin: function(anim) {
     changeBegan++;
@@ -3142,7 +3142,7 @@ var animation = anime.timeline({
   endDelay: 400,
   easing: 'easeInOutSine',
   update: function(anim) {
-    progressLogEl.value = 'progress : '+Math.round(anim.progress)+'%';
+    progressLogEl.value = 'progress : ' + Math.round(anim.progress)+'%';
   }
 }).add({
   translateX: 250
@@ -3487,7 +3487,7 @@ var easingNames = [
 
 function createEasingDemo(easing) {
   var demoEl = document.createElement('div');
-  demoEl.classList.add('el', 'square', 'stretched', 'easing-'+easing);
+  demoEl.classList.add('el', 'square', 'stretched', 'easing-' + easing);
   anime({
     targets: demoEl,
     translateY: [50, -50],


### PR DESCRIPTION
Minor clean-up to keep the documentation page crisp, clear, and consistent.

For example at https://animejs.com/documentation/#change

`progressLogEl.value = 'progress : '+Math.round(anim.progress)+'%';`

does not follow the same spacing as

`changeLogEl.value = 'changes : ' + changes;`

now:
`progressLogEl.value = 'progress : ' + Math.round(anim.progress) + '%';`

Other similar examples were also changed

