### PR TITLE
Avoid undefined classes when rendering server-side

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -893,6 +893,9 @@ const engine = (() => {
 })();
 
 function isDocumentHidden() {
+  if (typeof document === 'undefined') {
+    return true;
+  }
   return !!document && document.hidden;
 }
 
@@ -905,7 +908,7 @@ function anime(params = {}) {
   let resolve = null;
 
   function makePromise(instance) {
-    const promise = window.Promise && new Promise(_resolve => resolve = _resolve);
+    const promise = (typeof window !== 'undefined' && window.Promise) && new Promise(_resolve => resolve = _resolve);
     instance.finished = promise;
     return promise;
   }


### PR DESCRIPTION
It doesn't solve the problem of rendering server-side but helps to get closer.

I had to create polyfills for `SVGElement`, `NodeList` and `HTMLCollection` and some other methods.

But I could "successfully" use it server-side (at least it doesn't crash).

Helps to achieve: #889