### PR TITLE
fix: createScope root param type for ReactRef

### DIFF
--- a/lib/anime.esm.js
+++ b/lib/anime.esm.js
@@ -6407,7 +6407,7 @@ const createDraggable = (target, parameters) => new Draggable(target, parameters
 
 /**
  * @typedef {Object} ReactRef
- * @property {HTMLElement|SVGElement} [current]
+ * @property {HTMLElement|SVGElement|null} [current]
  */
 
 /**

--- a/src/scope.js
+++ b/src/scope.js
@@ -20,7 +20,7 @@ import {
 
 /**
  * @typedef {Object} ReactRef
- * @property {HTMLElement|SVGElement} [current]
+ * @property {HTMLElement|SVGElement|null} [current]
  */
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -771,7 +771,7 @@ declare class Scope {
 }
 declare function createScope(params?: ScopeParams): Scope;
 type ReactRef = {
-    current?: HTMLElement | SVGElement;
+    current?: HTMLElement | SVGElement | null;
 };
 type AngularRef = {
     nativeElement?: HTMLElement | SVGElement;

--- a/types/index.js
+++ b/types/index.js
@@ -5712,7 +5712,7 @@ const createDraggable = (target, parameters) => new Draggable(target, parameters
 
 /**
  * @typedef {Object} ReactRef
- * @property {HTMLElement|SVGElement} [current]
+ * @property {HTMLElement|SVGElement|null} [current]
  */
 /**
  * @typedef {Object} AngularRef


### PR DESCRIPTION
First, this is such an amazing library, thank you to everyone who has contributed to making it so lovely.

# Issue
The `createScope` method accepts `ScopeParams` which allows the `root` property to be `ReactRef` as part of the union and that type does not accept `null`.

The React libraries type definition for refs is currently: `type Ref<T> = RefCallback<T> | RefObject<T | null> | null;`

`null` is the valid state for React refs attached to DOM nodes during their initial render or when unmounting, so if `createScope` should allow passing the ref directly, as currently shown in the documentation, `null` should be allowed.

For example (from the current docs):
```jsx
// ...
const scope = useRef(null);

useEffect(() => {
  scope.current = createScope({ root })
// ...

return (
  <div ref={root}>
//...
```
This would currently have a typescript error for `root`: `Type 'null' is not assignable to type 'HTMLElement | SVGElement | undefined'`

---

I did not encounter any type errors that did not already exist (on "master" there is currently an `AbortSignal` error), and since the `Scope` class does a truthy check (`if (rootParam) { //... }`) I believe this change shouldn't cause any issues since `undefined` is already accounted for and not explicitly checked.