### PR TITLE
[DOCS] Typo correction for releaseDamping documentation

### DIFF
--- a/documentation/draggable/draggable-settings/releasedamping/index.html
+++ b/documentation/draggable/draggable-settings/releasedamping/index.html
@@ -1877,7 +1877,7 @@
         </h1>
         <p>Specifies the damping applied to the dragged element after release. Affects the speed, movement distance and bounciness of the dragged element. Lower values increases the bounciness when reaching the bounds of the container.</p>
 <div class="block warning">
-<p><code>releaseDamping</code> has no effect if a spring is passed to the <a href="/documentation/draggable/draggable-settings/releaseease">releaseDamping</a> parameter and is overridden by the spring <code>damping</code> value.</p>
+<p><code>releaseDamping</code> has no effect if a spring is passed to the <a href="/documentation/draggable/draggable-settings/releaseease">releaseEase</a> parameter and is overridden by the spring <code>damping</code> value.</p>
 </div>
 <h2>Accepts</h2>
 <p>A <code>Number</code> between <code>0</code> and <code>1000</code></p>


### PR DESCRIPTION
Corrects the user warning regarding the interaction of a spring and the release parameters.


Before:

```md
releaseDamping has no effect if a spring is passed to the releaseDamping parameter and is overridden by the spring damping value.
```

After:

```md
releaseDamping has no effect if a spring is passed to the releaseEase parameter and is overridden by the spring damping value.
```