### PR TITLE
chore: add @types/node dependency for type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",
+    "@types/node": "^24.3.0",
     "browser-sync": "^2.29.3",
     "chai": "^4.3.10",
     "mocha": "^10.2.0",


### PR DESCRIPTION
`setImmediate` and `clearImmediate` will prompt type errors