### PR TITLE
fix: error on ts when using await on anime functions

### DIFF
--- a/src/animation/animation.js
+++ b/src/animation/animation.js
@@ -689,8 +689,8 @@ export class JSAnimation extends Timer {
   }
 
   /**
-   * @param  {Callback<this>} [callback]
-   * @return {Promise}
+   * @param  {(value?: any) => any} [callback]
+   * @return {PromiseLike<any>}
    */
   then(callback) {
     return super.then(callback);

--- a/src/timeline/timeline.js
+++ b/src/timeline/timeline.js
@@ -331,8 +331,8 @@ export class Timeline extends Timer {
   }
 
   /**
-   * @param  {Callback<this>} [callback]
-   * @return {Promise}
+   * @param  {(value?: any) => any} [callback]
+   * @return {PromiseLike<any>}
    */
   then(callback) {
     return super.then(callback);


### PR DESCRIPTION
Fixed issue: When using await with anime functions (animations, timelines, timers, and WAAPI animations), TypeScript would encounter infinite recursion errors. This was caused by the then method implementation that didn't properly handle async function contexts. https://github.com/juliangarnier/anime/issues/1043