### PR TITLE
fix: check for document existence to support React Native

### DIFF
--- a/src/core/consts.js
+++ b/src/core/consts.js
@@ -9,7 +9,7 @@ export const isBrowser = typeof window !== 'undefined';
 export const win = isBrowser ? /** @type {AnimeJSWindow} */(/** @type {unknown} */(window)) : null;
 
 /** @type {Document|null} */
-export const doc = isBrowser ? document : null;
+export const doc = isBrowser && typeof document !== 'undefined' ? document : null;
 
 // Enums
 


### PR DESCRIPTION
Fixes #1017

## Summary
Fixed a ReferenceError that occurred when using anime.js in React Native environments. React Native has a `window` object but does not have a `document` object, which caused the library to throw "Property 'document' doesn't exist" error on import.

## Changes
- Added an explicit check for `document` existence in `src/core/consts.js` before accessing it
- Changed `export const doc = isBrowser ? document : null;` to `export const doc = isBrowser && typeof document !== 'undefined' ? document : null;`

## Testing
Verified that the JavaScript parses correctly. This is a minimal, surgical fix that only affects the document detection logic.

```diff
$ git diff --stat HEAD~1
src/core/consts.js | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```