### PR TITLE
fix(types): correct Reversed and Alternate casing in WAAPIAnimationOptions

### DIFF
--- a/dist/modules/types/index.d.ts
+++ b/dist/modules/types/index.d.ts
@@ -264,8 +264,8 @@ export type WAAPITweenOptions = {
 };
 export type WAAPIAnimationOptions = {
     loop?: number | boolean;
-    Reversed?: boolean;
-    Alternate?: boolean;
+    reversed?: boolean;
+    alternate?: boolean;
     autoplay?: boolean | ScrollObserver;
     playbackRate?: number;
     duration?: number | WAAPIFunctionValue;

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -413,8 +413,8 @@ export {}
 /**
  * @typedef {Object} WAAPIAnimationOptions
  * @property {Number|Boolean} [loop]
- * @property {Boolean} [Reversed]
- * @property {Boolean} [Alternate]
+ * @property {Boolean} [reversed]
+ * @property {Boolean} [alternate]
  * @property {Boolean|ScrollObserver} [autoplay]
  * @property {Number} [playbackRate]
  * @property {Number|WAAPIFunctionValue} [duration]

--- a/tests/suites/waapi.test.js
+++ b/tests/suites/waapi.test.js
@@ -126,6 +126,39 @@ suite('WAAPI', () => {
     expect(utils.get(targets[0], 'translate')).to.equal('100px');
   });
 
+  test('reversed option should start at the target value', () => {
+    const [ target ] = utils.$('#target-id');
+    const animation = waapi.animate(target, {
+      translate: '100px',
+      reversed: true,
+      duration: 20,
+      autoplay: false,
+      ease: 'linear',
+    });
+    animation.seek(0).commitStyles();
+    expect(utils.get(target, 'translate')).to.equal('100px');
+    animation.seek(20).commitStyles();
+    expect(utils.get(target, 'translate')).to.equal('0px');
+    utils.remove(target, null, 'translate');
+  });
+
+  test('alternate option should reverse direction on even loops', () => {
+    const [ target ] = utils.$('#target-id');
+    const animation = waapi.animate(target, {
+      translate: '100px',
+      loop: 2,
+      alternate: true,
+      duration: 20,
+      autoplay: false,
+      ease: 'linear',
+    });
+    animation.seek(5).commitStyles();
+    expect(utils.get(target, 'translate')).to.equal('25px');
+    animation.seek(25).commitStyles();
+    expect(utils.get(target, 'translate')).to.equal('75px');
+    utils.remove(target, null, 'translate');
+  });
+
   test('Set and get progress on an animation', () => {
     const targets = utils.$('.target-class');
     const animation = waapi.animate(targets, {


### PR DESCRIPTION
## Bug report

Fixes #1113

## What changed

In src/types/index.js, the \WAAPIAnimationOptions\ JSDoc typedef had:
\\\
@property {Boolean} [Reversed]
@property {Boolean} [Alternate]
\\\

But the actual runtime code in \src/waapi/waapi.js\ reads:
\\\js
const alternate = params.alternate ...
const reversed  = params.reversed  ...
\\\

The uppercase first-letter caused the generated \index.d.ts\ to export incorrect property names, so TypeScript users got type errors when using the correct \eversed\/\lternate\ (lowercase) form.

## Fix

Changed \[Reversed]\  \[reversed]\ and \[Alternate]\  \[alternate]\ in the \WAAPIAnimationOptions\ typedef, and rebuilt \dist/modules/types/index.d.ts\.

## Tests

Added two tests in \	ests/suites/waapi.test.js\:
- **\eversed\ option** — verifies that seeking to \